### PR TITLE
Also setting destination values

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
 node-proxywrap
 ==============
 
-This module wraps node's various `Server` interfaces so that they are compatible with the [PROXY protocol](http://haproxy.1wt.eu/download/1.5/doc/proxy-protocol.txt).  It automatically parses the PROXY headers and resets `socket.remoteAddress` and `socket.remotePort` so that they have the correct values.
+This module wraps node's various `Server` interfaces so that they are compatible with the [PROXY protocol](http://haproxy.1wt.eu/download/1.5/doc/proxy-protocol.txt). It automatically parses the PROXY headers and resets the following socket properties so that they have the correct values:
+
+    socket.sourceAddress
+    socket.sourcePort
+    socket.destinationAddress
+    socket.destinationPort
+
+Install it with:
 
     npm install proxywrap
 
@@ -23,7 +30,8 @@ proxywrap is a drop-in replacement.  Here's a simple Express app:
         , srv = proxiedHttp.createServer(app); // instead of http.createServer(app)
 
     app.get('/', function(req, res) {
-        res.send('IP = ' + req.connection.remoteAddress + ':' + req.connection.remotePort);
+        res.send('FROM IP = ' + req.connection.sourceAddress      + ':' + req.connection.sourcePort);
+        res.send('  TO IP = ' + req.connection.destinationAddress + ':' + req.connection.destinationPort);
     });
 
     srv.listen(80);

--- a/proxywrap.js
+++ b/proxywrap.js
@@ -121,14 +121,23 @@ exports.proxy = function(iface) {
 					var hlen = header.length;
 					header = header.split(' ');
 
-					Object.defineProperty(socket, 'remoteAddress', {
+					Object.defineProperty(socket, 'sourceAddress', {
 						enumerable: false,
 						configurable: true,
 						get: function() {
 							return header[2];
 						}
 					});
-					Object.defineProperty(socket, 'remotePort', {
+
+					Object.defineProperty(socket, 'destinationAddress', {
+						enumerable: false,
+						configurable: true,
+						get: function() {
+							return header[3];
+						}
+					});
+ 
+					Object.defineProperty(socket, 'sourcePort', {
 						enumerable: false,
 						configurable: true,
 						get: function() {
@@ -136,6 +145,14 @@ exports.proxy = function(iface) {
 						}
 					});
 
+					Object.defineProperty(socket, 'destinationPort', {
+						enumerable: false,
+						configurable: true,
+						get: function() {
+							return parseInt(header[5], 10);
+						}
+					});
+ 
 					// unshifting will fire the readable event
 					socket.emit = realEmit;
 					socket.unshift(buf.slice(crlf+2));


### PR DESCRIPTION
On the changes, besides the mentioned above, I changed `remoteAddress` and
`remotePort` to `sourceAddress` and `sourcePort` respectively, which seemed to
be more related to the original spec. Then I added `destinationAddres` and
`destinationPort`.
