### PR TITLE
allow non-proxied requests

### DIFF
--- a/proxywrap.js
+++ b/proxywrap.js
@@ -126,24 +126,26 @@ exports.proxy = function(iface) {
 					var hlen = header.length;
 					header = header.split(' ');
 	
-					Object.defineProperty(socket, 'remoteAddress', {
-						enumerable: false,
-						configurable: true,
-						get: function() {
-							return header[2];
-						}
-					});
-					Object.defineProperty(socket, 'remotePort', {
-						enumerable: false,
-						configurable: true,
-						get: function() {
-							return parseInt(header[4], 10);
-						}
-					});
+					if( !proxyFaked ){
+						Object.defineProperty(socket, 'remoteAddress', {
+							enumerable: false,
+							configurable: true,
+							get: function() {
+								return header[2];
+							}
+						});
+						Object.defineProperty(socket, 'remotePort', {
+							enumerable: false,
+							configurable: true,
+							get: function() {
+								return parseInt(header[4], 10);
+							}
+						});
+					}
 
 					// unshifting will fire the readable event
 					socket.emit = realEmit;
-					socket.unshift(buf.slice( ( proxyFaked ? 0 : crlf+numToAdd ) ) );
+					socket.unshift(buf.slice( ( proxyFaked ? 0 : crlf+2 ) ) );
 
 
 					self.emit('proxiedConnection', socket);

--- a/proxywrap.js
+++ b/proxywrap.js
@@ -31,8 +31,16 @@ var util = require('util');
 // Wraps the given module (ie, http, https, net, tls, etc) interface so that
 // `socket.remoteAddress` and `remotePort` work correctly when used with the
 // PROXY protocol (http://haproxy.1wt.eu/download/1.5/doc/proxy-protocol.txt)
-exports.proxy = function(iface) {
+// strict option drops requests without proxy headers, enabled by default to match previous behavior, disable to allow both proxied and non-proxied requests
+exports.proxy = function(iface, strict) {
 	var exports = {};
+
+	if( strict === undefined ){
+		var isStrict = true;
+	}else{
+		var isStrict = strict;
+	}
+
 	// copy iface's exports to myself
 	for (var k in iface) exports[k] = iface[k];
 
@@ -113,8 +121,12 @@ exports.proxy = function(iface) {
 				
 				// if the first 5 bytes aren't PROXY, something's not right.
 				if (header.length >= 5 && header.substr(0, 5) != 'PROXY'){ 
-					header = 'PROXY TCP4 10.10.10.10 10.10.10.10 10 \r\n' + header;//return socket.destroy('PROXY protocol error');
-					proxyFaked = true;
+					if( isStrict ){
+						return socket.destroy('PROXY protocol error');
+					}else{
+						header = 'PROXY TCP4 10.10.10.10 10.10.10.10 10 \r\n' + header;
+						proxyFaked = true;
+					}
 				}
 
 				var crlf = header.indexOf('\r');


### PR DESCRIPTION
Dropping the requests that don't come through proxied makes this really hard to test, or move code around between servers/load balancers. This change just allows the request through, and only sets the remoteAddress and remotePort if the proxy header is there.
