### PR TITLE
Fix SPDY example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,12 @@ You can do the same with `net` (raw TCP streams), `https`, and `spdy`.  It will 
 
 *Note*: If you're wrapping [node-spdy](https://github.com/indutny/node-spdy), its exports are a little strange:
 
-    var proxiedSpdy = require('proxywrap').proxy(require('spdy').server);
+    var spdy = require('spdy');
+    var proxiedSpdy = require('proxywrap').proxy(spdy.server);
+    var express = require('express');
+    var app = express();
+    var srv = proxiedSpdy.create(spdyOpts, app);
+    srv.listen(80);
 
 **Warning:** By default, *all* traffic to your proxied server MUST use the PROXY protocol.  If the first five bytes received aren't `PROXY`, the connection will be dropped.  Obviously, the node server accepting PROXY connections should not be exposed directly to the internet; only the proxy (whether ELB, HAProxy, or something else) should be able to connect to node.
 


### PR DESCRIPTION
Using the original example didn't work for me, but the this amended version does. I'm not sure when this stopped working (or I'm doing something completely daft).

Here is the example script I used.

``` js
var http, proxiedHttp, proxywrap, server, spdyOpts;

http = require('spdy');

proxywrap = require('proxywrap');

proxiedHttp = proxywrap.proxy(http.server, {
  strict: false
});

spdyOpts = {
  plain: true,
  ssl: false
};

var app = function(req, res){};
server = proxiedHttp.create(spdyOpts, app);
server.listen(8888);
```

and here is the error I got with the example from the readme

```
tls.js:1122
    throw new Error('Missing PFX or certificate + private key.');
          ^
Error: Missing PFX or certificate + private key.
  at ProxiedServer.Server (tls.js:1122:11)
  at ProxiedServer.Server (https.js:35:14)
```
